### PR TITLE
feat(neo4j): get IOU by hash (cypher query)

### DIFF
--- a/lib/database/neo4j/queries/getIouByHash.js
+++ b/lib/database/neo4j/queries/getIouByHash.js
@@ -1,0 +1,20 @@
+'use strict'
+
+const uglifyQueryString = require('../utils/uglifyQueryString')
+
+const query = `
+  match (iou:IOU) where iou.id = $iou
+  optional match (iou)<-[:Clears]-(txn:Transaction)
+  return iou.id as iou, txn.id as txn
+`
+
+module.exports = {
+  txmode: 'read',
+  string: uglifyQueryString(query),
+  parser(result) {
+    return {
+      iou: result.get('iou'),
+      transaction: result.get('txn')
+    }
+  }
+}


### PR DESCRIPTION
- Adds Cypher query to retrieve an IOU by hash.
- Optionally returns the Transaction that cleared the IOU.